### PR TITLE
Change keyboard shortcuts for TextEditor

### DIFF
--- a/source/components/TextEditor/Bullet/DailyLogBullet.js
+++ b/source/components/TextEditor/Bullet/DailyLogBullet.js
@@ -207,12 +207,13 @@ class DailyLogBullet extends BaseBullet {
   }
 
   setBulletModifier(modifier) {
-    if (modifier === this.state.modifier){ // Allow modifiers to be toggled
-      modifier = 'none'
+    if (modifier === this.state.modifier) { // Allow modifiers to be toggled
+      this.state.modifier = 'none';
+    } else {
+      this.state.modifier = modifier;
     }
-    this.state.modifier = modifier;
     const inputElement = this.shadowRoot.querySelector('input');
-    Object.assign(inputElement.style, bulletModifiers[modifier]);
+    Object.assign(inputElement.style, bulletModifiers[this.state.modifier]);
   }
 
   setCompleted(isComplete) {

--- a/source/components/TextEditor/Bullet/DailyLogBullet.js
+++ b/source/components/TextEditor/Bullet/DailyLogBullet.js
@@ -112,7 +112,7 @@ class DailyLogBullet extends BaseBullet {
       'Shift',
       'Control',
       's', // save
-      'k', // complete & uncomplete toggle (strikethrough, remove strikethrough)
+      'X', // (with Shift) complete & uncomplete toggle (strikethrough, remove strikethrough)
       'i', // inspiration (italics)
       'b', // priority (bold)
       'r', // regular font style
@@ -244,7 +244,7 @@ class DailyLogBullet extends BaseBullet {
    * @returns {Boolean} true if shortcut was matched, false otherwise
    */
   keyDownListener() {
-    if (this.keysPressed.Control && this.keysPressed.k) {
+    if (this.keysPressed.Control && this.keysPressed.Shift && this.keysPressed.X) {
       this.editContent(bulletParameters.completed, !this.state.completed);
     } else if (this.keysPressed.Control && this.keysPressed.r) {
       this.editContent(bulletParameters.modifier, 'none');

--- a/source/components/TextEditor/Bullet/DailyLogBullet.js
+++ b/source/components/TextEditor/Bullet/DailyLogBullet.js
@@ -207,6 +207,9 @@ class DailyLogBullet extends BaseBullet {
   }
 
   setBulletModifier(modifier) {
+    if (modifier === this.state.modifier){ // Allow modifiers to be toggled
+      modifier = 'none'
+    }
     this.state.modifier = modifier;
     const inputElement = this.shadowRoot.querySelector('input');
     Object.assign(inputElement.style, bulletModifiers[modifier]);

--- a/source/components/TextEditor/Bullet/DailyLogBullet.js
+++ b/source/components/TextEditor/Bullet/DailyLogBullet.js
@@ -237,7 +237,7 @@ class DailyLogBullet extends BaseBullet {
    * Keydown keyboard listeners in addition to base listeners
    *
    * Shortcuts checked (in order):
-   * 1. Control + k
+   * 1. Control + Shift + x
    * 2. Control + r
    * 3. Control + b
    * 4. Control + i

--- a/source/components/TextEditor/Bullet/TaskBullet.js
+++ b/source/components/TextEditor/Bullet/TaskBullet.js
@@ -69,7 +69,7 @@ class TaskBullet extends BaseBullet {
       'Shift',
       'Control',
       's', // save
-      'k', // complete & uncomplete toggle (strikethrough, remove strikethrough)
+      'X', // complete & uncomplete toggle (strikethrough, remove strikethrough)
       'ArrowUp',
       'ArrowDown',
     ];
@@ -168,7 +168,7 @@ class TaskBullet extends BaseBullet {
    * @returns {Boolean} true if shortcut was matched, false otherwise
    */
   keyDownListener() {
-    if (this.keysPressed.Control && this.keysPressed.k) {
+    if (this.keysPressed.Control && this.keysPressed.Shift && this.keysPressed.X) {
       this.editContent(bulletParameters.completed, !this.state.completed);
     } else return false;
     return true;

--- a/source/components/TextEditor/Bullet/TaskBullet.js
+++ b/source/components/TextEditor/Bullet/TaskBullet.js
@@ -163,7 +163,7 @@ class TaskBullet extends BaseBullet {
    * Keydown keyboard listeners in addition to base listeners
    *
    * Shortcuts checked (in order):
-   * 1. Control + k
+   * 1. Control + Shift + x
    *
    * @returns {Boolean} true if shortcut was matched, false otherwise
    */

--- a/source/home-dailylog/home.html
+++ b/source/home-dailylog/home.html
@@ -69,10 +69,10 @@
                       <span class="keyboard-shortcut">Ctrl</span> + <span class="keyboard-shortcut">Shift</span> + <span class="keyboard-shortcut">X</span>: toggle complete bullet (strike/unstrike)
                     </div>
                     <div>
-                      <span class="keyboard-shortcut">Ctrl</span> + <span class="keyboard-shortcut">B</span>: priority bullet (bold)
+                      <span class="keyboard-shortcut">Ctrl</span> + <span class="keyboard-shortcut">B</span>: toggle priority bullet (bold)
                     </div>
                     <div>
-                      <span class="keyboard-shortcut">Ctrl</span> + <span class="keyboard-shortcut">I</span>: inspiration bullet (italics)
+                      <span class="keyboard-shortcut">Ctrl</span> + <span class="keyboard-shortcut">I</span>: toggle inspiration bullet (italics)
                     </div>
                     <div>
                       <span class="keyboard-shortcut">Ctrl</span> + <span class="keyboard-shortcut">R</span>: regular style bullet <br>


### PR DESCRIPTION
This PR closes #63 by changing shortcuts to the following scheme:

Daily Log Page:
Bullet Modifier shortcuts can now be toggled so:
`Ctrl` + `b` -> toggles priority (bold)
`Ctrl` + `i` -> toggles inspiration (italics)
`Ctrl` + `r` -> (unchanged) still sets the bullet modifier property to none
Note: Bold and italics cannot be used at the same time because that would be overlapping inspiration and priority modifiers

Daily Log, Monthly Log, Collections:
`Ctrl` + `Shift` + `X` -> toggles task completion (strikethrough)